### PR TITLE
:wrench: Add configurable build context to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,11 +5,12 @@ RUN pip install --no-cache-dir poetry==2.1.1
 
 WORKDIR /src
 
-COPY ./pyproject.toml ./poetry.lock ./
+ARG BUILD_CONTEXT=.
+COPY ${BUILD_CONTEXT}/pyproject.toml ${BUILD_CONTEXT}/poetry.lock ./
 RUN poetry install --no-root
 
-COPY ./acapy_agent ./acapy_agent
-COPY ./README.md /src
+COPY ${BUILD_CONTEXT}/acapy_agent ./acapy_agent
+COPY ${BUILD_CONTEXT}/README.md /src
 RUN poetry build
 
 FROM python:${python_version}-slim-bookworm AS main


### PR DESCRIPTION
Add `ARG BUILD_CONTEXT=.` parameter and update all `COPY`
commands to use `${BUILD_CONTEXT}` prefix instead of hardcoded
`./` paths.

This enables building Docker images when the build context is
not the current directory, which is necessary for git submodule
workflows where child repositories need to be built from a
parent repository context.

* Add `BUILD_CONTEXT` argument with default value of `.`
* Update `COPY` commands for `pyproject.toml`, `poetry.lock`,
  `acapy_agent`, and `README.md` to use configurable context

---

Required for https://github.com/didx-xyz/acapy-cloud/pull/1731